### PR TITLE
added a check for 3 digits after a % sign

### DIFF
--- a/deepsmiles/decode.py
+++ b/deepsmiles/decode.py
@@ -106,9 +106,15 @@ def decode_branches(deepsmiles, rings):
             else:
                 try:
                     digit = int(deepsmiles[i+1:i+3])
+                    num_digits = 2
+                    try: # Check if three digits follow the %
+                        digit = int(deepsmiles[i+1:i+4])
+                        num_digits = 3
+                    except:
+                        pass
                 except ValueError:
-                    raise exceptions.DecodeError(deepsmiles, i, "'%' should be followed by two digits")
-                i += 2
+                    raise exceptions.DecodeError(deepsmiles, i, "'%' should be followed by at least two digits")
+                i += num_digits
             ok = tree.add_ring_closure(idx, digit, bondchar)
             if not ok:
                 raise exceptions.DecodeError(deepsmiles, i, "There is no corresponding atom on which to place the ring opening symbol for the ring sized %s" % digit)


### PR DESCRIPTION
Addresses #17 

I tried to follow the existing format used in checking for the number of digits after a `%` sign. After it checks for 2, it will now also check for 3 digits. The number added to `i` will now depend on the number of digits that follow the `%`.

This fixed the issues of incorrect SMILES strings being returned I described in #17.

Let me know your thoughts. Maybe there is a more robust way to check the number of digits after a `%` symbol that isn't limited to 2 or 3.